### PR TITLE
Added 2 Tests

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -552,6 +552,12 @@ mod tests {
     }
 
     #[test]
+    fn multiply_huge()
+    {
+        tester("x=asin999 c=1*x if c==0then:output=\"ok\"else:output=\":(\"end goto1");
+    }
+
+    #[test]
     fn acid_acos() {
         tester(
 r#"x=acos(0)

--- a/src/simple_interp.rs
+++ b/src/simple_interp.rs
@@ -231,6 +231,12 @@ mod tests {
     }
 
     #[test]
+    fn multiply_huge()
+    {
+        tester(true, "x=asin999 c=1*x if c==0then:output=\"ok\"else:output=\":(\"end goto1");
+    }
+
+    #[test]
     fn acid_acos() {
         tester(true,
 r#"x=acos(0)


### PR DESCRIPTION
This case failed in Yolol.IL due to `a:bool * b:Number` optimising to `a ? b : 0`. This isn't true for very large or small numbers (`asin999` is just a handy way to generate `MINVAL`)